### PR TITLE
Fix NetInfo deprecated methods

### DIFF
--- a/templates/DeviceInfoScreen.js
+++ b/templates/DeviceInfoScreen.js
@@ -42,11 +42,11 @@ export default class DeviceInfoScreen extends React.Component {
   }
 
   componentDidMount () {
-    NetInfo.isConnected.addEventListener('change', this.setConnected)
+    NetInfo.isConnected.addEventListener('connectionChange', this.setConnected)
     NetInfo.isConnected.fetch().done(this.setConnected)
-    NetInfo.addEventListener('change', this.setConnectionInfo)
-    NetInfo.fetch().done(this.setConnectionInfo)
-    NetInfo.addEventListener('change', this.updateConnectionInfoHistory)
+    NetInfo.addEventListener('connectionChange', this.setConnectionInfo)
+    NetInfo.getConnectionInfo().done(this.setConnectionInfo)
+    NetInfo.addEventListener('connectionChange', this.updateConnectionInfoHistory)
 
     // an example of how to display a custom Reactotron message
     // console.tron.display({
@@ -61,9 +61,9 @@ export default class DeviceInfoScreen extends React.Component {
   }
 
   componentWillUnmount () {
-    NetInfo.isConnected.removeEventListener('change', this.setConnected)
-    NetInfo.removeEventListener('change', this.setConnectionInfo)
-    NetInfo.removeEventListener('change', this.updateConnectionInfoHistory)
+    NetInfo.isConnected.removeEventListener('connectionChange', this.setConnected)
+    NetInfo.removeEventListener('connectionChange', this.setConnectionInfo)
+    NetInfo.removeEventListener('connectionChange', this.updateConnectionInfoHistory)
   }
 
   setConnected = (isConnected) => {
@@ -83,7 +83,7 @@ export default class DeviceInfoScreen extends React.Component {
   netInfo () {
     return ([
       {title: 'Connection', info: (this.state.isConnected ? 'Online' : 'Offline')},
-      {title: 'Connection Info', info: this.state.connectionInfo},
+      {title: 'Connection Info', info: JSON.stringify(this.state.connectionInfo)},
       {title: 'Connection Info History', info: JSON.stringify(this.state.connectionInfoHistory)}
     ])
   }


### PR DESCRIPTION
This PR fixes issues described in #8 
![2017-11-14_13-42-30](https://user-images.githubusercontent.com/9068073/32776509-763a959e-c93b-11e7-87a7-ea4e095e70b6.png)

As the result of this changes Net Info section on the screen changed a little bit because a new `getConnectionInfo` method gives more information then previous `fetch` (in addition to connection type it gives an effectiveType)

![image](https://user-images.githubusercontent.com/9068073/32776575-aa706c30-c93b-11e7-9281-13565b3d2198.png)

I decided to keep both variables here. But maybe it makes sense to wrap up a result and show it as a string like `Mobile - 4g` instead of plain JSON object?