### PR TITLE
Add bottom padding to scroll views in example screens

### DIFF
--- a/templates/APITestingScreen.js
+++ b/templates/APITestingScreen.js
@@ -70,20 +70,22 @@ export default class APITestingScreen extends React.Component {
           <Image source={Images.backButton} />
         </TouchableOpacity>
         <ScrollView style={styles.container} ref='container'>
-          <View style={{alignItems: 'center', paddingTop: 60}}>
-            <Image source={Images.api} style={styles.logo} />
-            <Text style={styles.titleText}>API</Text>
+          <View style={styles.scrollContent}>
+            <View style={{alignItems: 'center', paddingTop: 60}}>
+              <Image source={Images.api} style={styles.logo} />
+              <Text style={styles.titleText}>API</Text>
+            </View>
+            <View style={styles.section}>
+              <Text style={styles.sectionText}>
+                Testing API with Postman or APIary.io verifies the server works.
+                The API Test screen is the next step; a simple in-app way to verify and debug your in-app API functions.
+              </Text>
+              <Text style={styles.sectionText}>
+                Create new endpoints in Services/Api.js then add example uses to endpoints array in Containers/APITestingScreen.js
+              </Text>
+            </View>
+            {this.renderButtons()}
           </View>
-          <View style={styles.section}>
-            <Text style={styles.sectionText}>
-              Testing API with Postman or APIary.io verifies the server works.
-              The API Test screen is the next step; a simple in-app way to verify and debug your in-app API functions.
-            </Text>
-            <Text style={styles.sectionText}>
-              Create new endpoints in Services/Api.js then add example uses to endpoints array in Containers/APITestingScreen.js
-            </Text>
-          </View>
-          {this.renderButtons()}
           <APIResult ref='result' />
         </ScrollView>
       </View>

--- a/templates/ComponentExamplesScreen.js
+++ b/templates/ComponentExamplesScreen.js
@@ -33,21 +33,22 @@ class ComponentExamplesScreen extends React.Component {
           <Image source={Images.backButton} />
         </TouchableOpacity>
         <ScrollView showsVerticalScrollIndicator={false} style={styles.container}>
-          <View style={{alignItems: 'center', paddingTop: 60}}>
-            <Image source={Images.components} style={styles.logo} />
-            <Text style={styles.titleText}>Components</Text>
-          </View>
-          <View style={styles.description}>
-            {this.renderAndroidWarning()}
-            <Text style={styles.sectionText}>
-              Sometimes called a 'Style Guide', or 'Pattern Library', Examples Screen is filled with usage examples
-              of fundamental components for a given application.  Use this merge-friendly way for your team
-              to show/use/test components.  Examples are registered inside each component's file for quick changes and usage identification.
-            </Text>
-          </View>
+          <View style={styles.scrollContent}>
+            <View style={{alignItems: 'center', paddingTop: 60}}>
+              <Image source={Images.components} style={styles.logo} />
+              <Text style={styles.titleText}>Components</Text>
+            </View>
+            <View style={styles.description}>
+              {this.renderAndroidWarning()}
+              <Text style={styles.sectionText}>
+                Sometimes called a 'Style Guide', or 'Pattern Library', Examples Screen is filled with usage examples
+                of fundamental components for a given application.  Use this merge-friendly way for your team
+                to show/use/test components.  Examples are registered inside each component's file for quick changes and usage identification.
+              </Text>
+            </View>
 
-          {ExamplesRegistry.renderComponentExamples()}
-
+            {ExamplesRegistry.renderComponentExamples()}
+          </View>
         </ScrollView>
       </View>
     )

--- a/templates/DevTheme/ApplicationStyles.js
+++ b/templates/DevTheme/ApplicationStyles.js
@@ -23,6 +23,9 @@ const ApplicationStyles = {
       paddingTop: Metrics.baseMargin,
       backgroundColor: Colors.transparent
     },
+    scrollContent: {
+      paddingBottom: 18
+    },
     section: {
       margin: Metrics.section,
       padding: Metrics.baseMargin

--- a/templates/DeviceInfoScreen.js
+++ b/templates/DeviceInfoScreen.js
@@ -129,20 +129,22 @@ export default class DeviceInfoScreen extends React.Component {
           <Image source={Images.backButton} />
         </TouchableOpacity>
         <ScrollView style={styles.container}>
-          <View style={{alignItems: 'center', paddingTop: 60}}>
-            <Image source={Images.deviceInfo} style={styles.logo} />
-            <Text style={styles.titleText}>Device Info</Text>
-          </View>
-          <View style={styles.section}>
-            <Text style={styles.sectionText} >
-              Dedicated to identifying specifics of the device.  All info useful for identifying outlying behaviour specific to a device.
-            </Text>
-          </View>
-          <View style={{padding: 10}}>
-            {this.renderCard('Device Hardware', HARDWARE_DATA)}
-            {this.renderCard('Device OS', OS_DATA)}
-            {this.renderCard('App Info', APP_DATA)}
-            {this.renderCard('Net Info', this.netInfo())}
+          <View style={styles.scrollContent}>
+            <View style={{alignItems: 'center', paddingTop: 60}}>
+              <Image source={Images.deviceInfo} style={styles.logo} />
+              <Text style={styles.titleText}>Device Info</Text>
+            </View>
+            <View style={styles.section}>
+              <Text style={styles.sectionText} >
+                Dedicated to identifying specifics of the device.  All info useful for identifying outlying behaviour specific to a device.
+              </Text>
+            </View>
+            <View style={{padding: 10}}>
+              {this.renderCard('Device Hardware', HARDWARE_DATA)}
+              {this.renderCard('Device OS', OS_DATA)}
+              {this.renderCard('App Info', APP_DATA)}
+              {this.renderCard('Net Info', this.netInfo())}
+            </View>
           </View>
         </ScrollView>
       </View>

--- a/templates/FaqScreen.js
+++ b/templates/FaqScreen.js
@@ -18,37 +18,39 @@ class FaqScreen extends React.Component {
           <Image source={Images.backButton} />
         </TouchableOpacity>
         <ScrollView showsVerticalScrollIndicator={false} style={styles.container}>
-          <View style={{alignItems: 'center', paddingTop: 60}}>
-            <Image source={Images.faq} style={styles.logo} />
-            <Text style={styles.titleText}>FAQ</Text>
-          </View>
-          <View style={styles.description}>
-            <Text style={styles.sectionText}>
-              Have questions? We direct you to answers.  This is a small taste of where to get more information depending on what it is that you want to know.
-            </Text>
-          </View>
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>What are these screens?</Text>
-            <Text style={styles.sectionText}>We like to use these screens when we develop apps. They are optional and out of the way to help you along your app creation process.  Each screen has an explanation of what it provides.  More info can be found on our website http://infinite.red/ignite</Text>
-          </View>
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>Got Docs?</Text>
-            <Text style={styles.sectionText}>The GitHub page has a docs folder that can help you from beginner to expert!  We'll be working to release some instructional video docs as well.</Text>
-          </View>
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>I don't see the answer to my question in docs</Text>
-            <Text style={styles.sectionText}>Besides our docs, we have a friendly community Slack.  Get an invite from http://community.infinite.red and you'll find a community of people in the #ignite channel ready to help!</Text>
-          </View>
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>What can I customize?</Text>
-            <Text style={styles.sectionText}>Everything!  We're open source with MIT license.  We also make it easy to change whatever you like.  Check on our guides for making your very own plugins and boilerplates with Ignite.</Text>
-          </View>
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>I love you</Text>
-            <Text style={styles.sectionText}>
-              We love you, too.  Don't forget to tweet us 😘
-              @infinite_red OR @ir_ignite
-            </Text>
+          <View style={styles.scrollContent}>
+            <View style={{alignItems: 'center', paddingTop: 60}}>
+              <Image source={Images.faq} style={styles.logo} />
+              <Text style={styles.titleText}>FAQ</Text>
+            </View>
+            <View style={styles.description}>
+              <Text style={styles.sectionText}>
+                Have questions? We direct you to answers.  This is a small taste of where to get more information depending on what it is that you want to know.
+              </Text>
+            </View>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>What are these screens?</Text>
+              <Text style={styles.sectionText}>We like to use these screens when we develop apps. They are optional and out of the way to help you along your app creation process.  Each screen has an explanation of what it provides.  More info can be found on our website http://infinite.red/ignite</Text>
+            </View>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>Got Docs?</Text>
+              <Text style={styles.sectionText}>The GitHub page has a docs folder that can help you from beginner to expert!  We'll be working to release some instructional video docs as well.</Text>
+            </View>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>I don't see the answer to my question in docs</Text>
+              <Text style={styles.sectionText}>Besides our docs, we have a friendly community Slack.  Get an invite from http://community.infinite.red and you'll find a community of people in the #ignite channel ready to help!</Text>
+            </View>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>What can I customize?</Text>
+              <Text style={styles.sectionText}>Everything!  We're open source with MIT license.  We also make it easy to change whatever you like.  Check on our guides for making your very own plugins and boilerplates with Ignite.</Text>
+            </View>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>I love you</Text>
+              <Text style={styles.sectionText}>
+                We love you, too.  Don't forget to tweet us 😘
+                @infinite_red OR @ir_ignite
+              </Text>
+            </View>
           </View>
         </ScrollView>
       </View>

--- a/templates/PluginExamplesScreen.js
+++ b/templates/PluginExamplesScreen.js
@@ -8,6 +8,8 @@ import { Images } from './DevTheme'
 
 // Examples Render Engine
 import ExamplesRegistry from '../../App/Services/ExamplesRegistry'
+import '../Examples/Components/animatableExample.js'
+import '../Examples/Components/vectorExample.js'
 
 // Styles
 import styles from './Styles/PluginExamplesScreenStyles'
@@ -26,21 +28,22 @@ class PluginExamplesScreen extends React.Component {
           <Image source={Images.backButton} />
         </TouchableOpacity>
         <ScrollView style={styles.container}>
-          <View style={{alignItems: 'center', paddingTop: 60}}>
-            <Image source={Images.usageExamples} style={styles.logo} />
-            <Text style={styles.titleText}>Plugin Examples</Text>
+          <View style={styles.scrollContent}>
+            <View style={{alignItems: 'center', paddingTop: 60}}>
+              <Image source={Images.usageExamples} style={styles.logo} />
+              <Text style={styles.titleText}>Plugin Examples</Text>
+            </View>
+            <View style={styles.section}>
+              <Text style={styles.sectionText} >
+                The Plugin Examples screen is a playground for 3rd party libs and logic proofs.
+                Items on this screen can be composed of multiple components working in concert.  Functionality demos of libs and practices
+              </Text>
+            </View>
+
+            {ExamplesRegistry.renderPluginExamples()}
+
+            <View style={styles.screenButtons} />
           </View>
-          <View style={styles.section}>
-            <Text style={styles.sectionText} >
-              The Plugin Examples screen is a playground for 3rd party libs and logic proofs.
-              Items on this screen can be composed of multiple components working in concert.  Functionality demos of libs and practices
-            </Text>
-          </View>
-
-          {ExamplesRegistry.renderPluginExamples()}
-
-          <View style={styles.screenButtons} />
-
         </ScrollView>
       </View>
     )

--- a/templates/ThemeScreen.js
+++ b/templates/ThemeScreen.js
@@ -63,30 +63,31 @@ export default class ThemeScreen extends React.Component {
           <Image source={Images.backButton} />
         </TouchableOpacity>
         <ScrollView style={styles.container}>
-          <View style={{alignItems: 'center', paddingTop: 60}}>
-            <Image source={Images.theme} style={styles.logo} />
-            <Text style={styles.titleText}>Themes</Text>
-          </View>
-          <View style={styles.section} key='colors-header'>
-            <Text style={styles.sectionText} key='colors'>List of Theme specific settings.  Auto-generated from Themes folder.</Text>
-          </View>
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>Colors</Text>
-          </View>
-          <View style={styles.colorsContainer}>
-            {this.renderColors()}
-          </View>
+          <View style={styles.scrollContent}>
+            <View style={{alignItems: 'center', paddingTop: 60}}>
+              <Image source={Images.theme} style={styles.logo} />
+              <Text style={styles.titleText}>Themes</Text>
+            </View>
+            <View style={styles.section} key='colors-header'>
+              <Text style={styles.sectionText} key='colors'>List of Theme specific settings.  Auto-generated from Themes folder.</Text>
+            </View>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>Colors</Text>
+            </View>
+            <View style={styles.colorsContainer}>
+              {this.renderColors()}
+            </View>
 
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>Fonts</Text>
-          </View>
-          {this.renderFonts()}
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>Fonts</Text>
+            </View>
+            {this.renderFonts()}
 
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeader}>Styles</Text>
+            <View style={styles.sectionHeaderContainer}>
+              <Text style={styles.sectionHeader}>Styles</Text>
+            </View>
+            {this.renderStyles()}
           </View>
-          {this.renderStyles()}
-
         </ScrollView>
       </View>
     )


### PR DESCRIPTION
Some of the example screens cutoff the last bit of content when using scrollviews. This just adds a new `scrollContent` application style to use within those scrollviews to prevent that.