### PR TITLE
Removed old react-navigation installation

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -21,9 +21,6 @@ const add = async function (context) {
   // Set Android Permission for NetInfo module
   ignite.addAndroidPermission('ACCESS_NETWORK_STATE')
 
-  // dev screens use react-navigation
-  await ignite.addModule('react-navigation', { version: '1.0.0-beta.11' })
-
   // react-native-device-info
   await ignite.addModule('react-native-device-info', { link: true, version: '0.11.0' })
 
@@ -62,8 +59,6 @@ const remove = async function (context) {
   ignite.removeIgniteConfig('examples')
 
   await ignite.removeModule('react-native-device-info', { unlink: true })
-  // remove the npm module - probably should ask user here
-  await ignite.removeModule('react-navigation')
 
   // Set Android Permission for NetInfo module
   // NOTE(steve): this is too presumptious


### PR DESCRIPTION
It reverts react-navigation's version to 1.0.0 and causes error on new boilerplates